### PR TITLE
Add compatibility with Slack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,4 @@ See [the official docs](https://docs.drone.io/extend/config) for extra informati
 Below are a list of config plugins that are known to be compatible with this plugin. If you know of any that are missing, please open a PR.
 
 [Changeset Conditional](https://github.com/microadam/drone-config-changeset-conditional)
+[Always Notify Slack](https://github.com/goodwillaz/drone-config-plugin-slack)


### PR DESCRIPTION
I've created a Drone config plugin for automatically adding slack notifications to pipelines which I've also made compatible with this plugin.